### PR TITLE
add "ignore pinned tabs" option

### DIFF
--- a/src/nufftabs.js
+++ b/src/nufftabs.js
@@ -42,6 +42,9 @@ function init() {
 	if (localStorage.maxTabs == undefined) {
 		localStorage.maxTabs = 20; // default
 	}
+	if (localStorage.ignorePinned == undefined) {
+		localStorage.ignorePinned = false;
+	}
 	if (localStorage.showCount == undefined) {
 		localStorage.showCount = false;
 	}
@@ -113,8 +116,14 @@ function checkTabAdded(newTabId) {
 	
 	// check tabs of current window
 	chrome.tabs.query({ currentWindow: true }, function(tabs) {
+
+		if (localStorage.ignorePinned == '1') {
+			tabs = tabs.filter(function (tab) {
+				return !tab.pinned;
+			});
+		}
 		
-		//debugLog("num of tabs: " +tabs.length)
+		// debugLog("num of tabs: " +tabs.length)
 		
 		// tab removal criterion
 		while (tabs.length > localStorage.maxTabs) {

--- a/src/options.html
+++ b/src/options.html
@@ -57,6 +57,12 @@ body {
   <option value="random">random</option>
 </select>
 
+<p>Ignore pinned tabs:</p>
+<select id="ignorePinned">
+  <option value="0">no</option>
+  <option value="1">yes</option>
+</select>
+
 <p>Show tab count:</p>
 <select id="showCount">
   <option value="0">no</option>

--- a/src/options.js
+++ b/src/options.js
@@ -25,6 +25,15 @@ function init() {
 		}
 	}
 
+	var selector = document.getElementById("ignorePinned");
+	for (var i = 0; i < selector.children.length; i++) {
+		var child = selector.children[i];
+		if (child.value == ignorePinned) {
+			child.selected = "true";
+		break;
+		}
+	}
+
 	var selector = document.getElementById("showCount");
 	for (var i = 0; i < selector.children.length; i++) {
 		var child = selector.children[i];
@@ -38,6 +47,7 @@ function init() {
 function saveMe() {
 	localStorage.maxTabs = document.getElementById("maxTabs").value;
 	localStorage.discardCriterion = document.getElementById("discardCriterion").value;
+	localStorage.ignorePinned = document.getElementById("ignorePinned").value;
 	localStorage.showCount = document.getElementById("showCount").value;
 
 	document.getElementById('messages').innerHTML = "Options saved.";
@@ -53,6 +63,7 @@ function closeMe() {
 function saveClose() {
 	localStorage.maxTabs = document.getElementById("maxTabs").value;
 	localStorage.discardCriterion = document.getElementById("discardCriterion").value;
+	localStorage.ignorePinned = document.getElementById("ignorePinned").value;
 	localStorage.showCount = document.getElementById("showCount").value;
 
 	document.getElementById('messages').innerHTML = "Options saved.";


### PR DESCRIPTION
Adds an option (disabled by default) to ignore pinned tabs. When enabled, this means pinned tabs don't get counted, so you can have as many as you want. Also it should prevent them ever getting closed.
